### PR TITLE
Merging redirect uri updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ author: vibronet
 ---
 
 # UWP - works #
-# iOS - works, but redirectURI needs revision #
-# Android - works, but redirectURI needs revision #
+# iOS - works#
+# Android - works #
 ----
 
 # Integrate Microsoft identity and the Microsoft Graph into a Xamarin forms app using MSAL

--- a/UserDetailsClient/UserDetailsClient.Droid/MainActivity.cs
+++ b/UserDetailsClient/UserDetailsClient.Droid/MainActivity.cs
@@ -20,7 +20,7 @@ namespace UserDetailsClient.Droid
 
             global::Xamarin.Forms.Forms.Init(this, bundle);
             LoadApplication(new App());
-            App.PCA.RedirectUri = "vibro://sampledomain/sampleapp";
+            App.PCA.RedirectUri = "msala7d8cef0-4145-49b2-a91d-95c54051fa3f://auth";
             App.UiParent = new UIParent(Xamarin.Forms.Forms.Context as Activity);           
         }
 

--- a/UserDetailsClient/UserDetailsClient.Droid/Properties/AndroidManifest.xml
+++ b/UserDetailsClient/UserDetailsClient.Droid/Properties/AndroidManifest.xml
@@ -9,7 +9,7 @@
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
-        <data android:scheme="vibro" android:host="sampledomain" />
+        <data android:scheme="msala7d8cef0-4145-49b2-a91d-95c54051fa3f" android:host="auth" />
       </intent-filter>
     </activity>
   </application>

--- a/UserDetailsClient/UserDetailsClient.iOS/AppDelegate.cs
+++ b/UserDetailsClient/UserDetailsClient.iOS/AppDelegate.cs
@@ -26,7 +26,7 @@ namespace UserDetailsClient.iOS
             global::Xamarin.Forms.Forms.Init();
             LoadApplication(new App());
             //App.PCA.RedirectUri = "vibro://sampledomain/sampleapp";
-            App.PCA.RedirectUri = "vibro://com.yourcompany.UserDetailsClient";
+            App.PCA.RedirectUri = "msala7d8cef0-4145-49b2-a91d-95c54051fa3f://auth";
             return base.FinishedLaunching(app, options);            
         }
 

--- a/UserDetailsClient/UserDetailsClient.iOS/Info.plist
+++ b/UserDetailsClient/UserDetailsClient.iOS/Info.plist
@@ -30,7 +30,7 @@
        <string>com.yourcompany.UserDetailsClient</string>
        <key>CFBundleURLSchemes</key>
        <array>
-         <string>vibro</string>
+         <string>msala7d8cef0-4145-49b2-a91d-95c54051fa3f</string>
        </array>
      </dict>
    </array>


### PR DESCRIPTION
Updated the Redirect URI for iOS & Android. Moreover, updated the headings for iOS and Android in the Readme.  Right now, developers will be required to register the `msal<clientID>://auth` format, but will have it pre-registered by release. 

