### PR TITLE
Cleaning-up the sample:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
 ---
 services: active-directory
-platforms: dotnet, xamarin
+platforms: dotnet, xamarin.iOS, xamarin.Android, UWP
 author: jmprieur
+level:  300
+client: Xamarin 
+service: Microsoft Graph 
+endpoint: AAD V2
 ---
 
-
 # Integrate Microsoft identity and the Microsoft Graph into a Xamarin forms app using MSAL
-This is a simple Xamarin Forms app showcasing how to use MSAL to authenticate MSA and Azure AD via the converged MSA and Azure AD authentication endpoints, and access the Microsoft Graph with the resulting token.
+This is a simple [Xamarin Forms](https://www.xamarin.com/visual-studio) app showcasing how to use MSAL.NET to authenticate users with Work or School accounts (AAD) or Microsoft personal accounts (MSA) and access the Microsoft Graph with the resulting token.
 
-For more information about how the protocols work in this scenario and other scenarios, see [Authentication Scenarios for Azure AD](http://go.microsoft.com/fwlink/?LinkId=394414).
-For more information about Microsoft Graph, please visit [the Microsoft Graph homepage](https://graph.microsoft.io/en-us/).
 
-## How To Run This Sample
+## How To Run this Sample
 
 To run this sample you will need:
-- Visual Studio 2017
+- [Visual Studio 2017](https://aka.ms/vsdownload) with the **Mobile development with .NET** [workload](https://www.visualstudio.com/vs/visual-studio-workloads/)
 - An Internet connection
 - At least one of the following accounts:
-- A Microsoft Account
-- An Azure AD account
+  - A Microsoft Account
+  - An Azure AD account
+ - for UWP, if you want to test the UWP application, you want to add the SDK corresponding to your version of Windows 10 (or all the Windows 10 SDKs). See [Testing UWP applications on Windows 10](#Testing-UWP-applications-on-Windows-10)
 
 You can get a Microsoft Account for free by choosing the Sign up option while visiting [https://www.microsoft.com/en-us/outlook-com/](https://www.microsoft.com/en-us/outlook-com/). 
 You can get an Office365 office subscription, which will give you an Azure AD account, at [https://products.office.com/en-us/try](https://products.office.com/en-us/try). 
@@ -28,7 +30,8 @@ You can get an Office365 office subscription, which will give you an Azure AD ac
 
 From your shell or command line:
 
-`git clone https://github.com/Azure-Samples/active-directory-xamarin-native-v2.git`
+> Given that the name of the sample is pretty long, and so are the name of the referenced NuGet packages, you might want to clone it in a folder close to the root of your hard drive, to avoid file size limitations on Windows.
+
 
 ### [OPTIONAL] Step 2:  Register the sample on the app registration portal
 
@@ -36,7 +39,7 @@ You can run the sample as is with its current settings, or you can optionally re
 Create a new app at [apps.dev.microsoft.com](https://apps.dev.microsoft.com), or follow these [detailed steps](https://azure.microsoft.com/en-us/documentation/articles/active-directory-v2-app-registration/).  Make sure to:
 
 - Copy down the **Application Id** assigned to your app, you'll need it in the next optional step.
-- Add the **Mobile** platform for your app.
+- Add the **Native Application** platform for your app.
 
 ### [OPTIONAL] Step 3:  Configure the Visual Studio project with your app coordinates
 
@@ -49,7 +52,7 @@ Create a new app at [apps.dev.microsoft.com](https://apps.dev.microsoft.com), or
 2. Locate the `App.PCA.RedirectUri` assignment, and change it to assign the string `"msal<Application Id>://auth"` where `<Application Id>` is the identifier you copied in step 2
 3. Open the `UserDetailsClient.iOS\info.plist` file in a text editor (opening it in Visual Studio won't work for this step as you need to edit the text)
 4. In the URL types, section, add an entry for the authorization schema used in your redirectUri.
-```
+```Xml
     <key>CFBundleURLTypes</key>
        <array>
      <dict>
@@ -65,13 +68,14 @@ Create a new app at [apps.dev.microsoft.com](https://apps.dev.microsoft.com), or
        </array> 
 ```
 where `[APPLICATIONID]` is the identifier you copied in step 2. Save the file.
+
 #### [OPTIONAL] Step 3b: Configure the Android project with your return URI
 
 1. Open the `UserDetailsClient.Droid\MainActivity.cs` file.
 2. Locate the `App.PCA.RedirectUri` assignment, and change it to assign the string `"msal<Application Id>://auth"` where `<Application Id>` is the identifier you copied in step 2
 3. Open the `UserDetailsClient.Droid\Properties\AndroidManifest.xml`
 4. Add or modify the `<application>` element as in the following
-```
+```Xml
     <application>
     <activity android:name="microsoft.identity.client.BrowserTabActivity">
       <intent-filter>
@@ -88,81 +92,80 @@ where `[APPLICATIONID]` is the identifier you copied in step 2. Save the file.
 ### Step 4:  Run the sample
 
 Choose the platform you want to work on by setting the startup project in the Solution Explorer. Make sure that your platform of choice is marked for build and deploy in the Configuration Manager.
-Clean the solution, rebuild the solution, and run it.
-Click the sign-in button at the bottom of the application screen. On the sign-in screen, enter the name and password of a personal Microsoft account or a work/school account. The sample works exactly in the same way regardless of the account type you choose, apart from some visual differences in the authentication and consent experience.During the sign in process, you will be prompted to grant various permissions.   
-Upon successful sign in and consent, the application screen will list some basic profile info for the authenticated user. Also, the button at the bottom of the screen will turn into a Sign out button.
-Close the application and reopen it. You will see that the app retains access to the API and retrieves the user info right away, without the need to sign in again.
-Sign out by clicking the Sign out button and confirm that you lose access to the API until the enxt interactive sign in.
+Clean the solution, rebuild the solution, and run it:
+- Click the sign-in button at the bottom of the application screen. On the sign-in screen, enter the name and password of a personal Microsoft account or a work/school account. The sample works exactly in the same way regardless of the account type you choose, apart from some visual differences in the authentication and consent experience. During the sign in process, you will be prompted to grant various permissions (to allow the application to access your data)   
+- Upon successful sign in and consent, the application screen will list some basic profile info for the authenticated user. Also, the button at the bottom of the screen will turn into a Sign out button.
+- Close the application and reopen it. You will see that the app retains access to the API and retrieves the user info right away, without the need to sign in again.
+- Sign out by clicking the Sign out button and confirm that you lose access to the API until the enxt interactive sign in.
 
 #### Running in an Android Emulator
-MSAL in Android requires support for Chrome Custom Tabs for displaying authentication prompts.
+MSAL.NET in Android requires support for Chrome Custom Tabs for displaying authentication prompts.
 Not every emulator image comes with Chrome on board: please refer to [this document](https://github.com/Azure-Samples/active-directory-general-docs/blob/master/AndroidEmulator.md) for instructions on how to ensure that your emulator supports the features required by MSAL. 
 
 ## About the code
-The structure of the solution is straightforward. All the application logic and UX reside in UserDetailsClient (portable).
-MSAL's main primitive for native clients, `PublicClientApplication`, is initialized as a static variable in App.cs.
-At application startup, the main page attempts to get a token without showing any UX - just in case a suitable token is already present in the cache from previous sessions. This is the code performing that logic:
-```
-protected override async void OnAppearing()
-{
-    // let's see if we have a user in our belly already
-    try
+The structure of the solution is straightforward. All the application logic and UX reside in ``UserDetailsClient (portable)`` project.
+- MSAL's main primitive for native clients, `PublicClientApplication`, is initialized as a static variable in App.cs (For details see [Client applications in MSAL.NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Client-Applications))
+- At application startup, the main page attempts to get a token without showing any UX - just in case a suitable token is already present in the cache from previous sessions. This is the code performing that logic:
+    ```C#
+    protected override async void OnAppearing()
     {
-        AuthenticationResult ar = 
-            await App.PCA.AcquireTokenSilentAsync(App.Scopes, App.PCA.Users.FirstOrDefault());
-        RefreshUserData(ar.AccessToken);
-        btnSignInSignOut.Text = "Sign out";
+        // let's see if we have a user in our belly already
+        try
+        {
+            AuthenticationResult ar = 
+              await App.PCA.AcquireTokenSilentAsync(App.Scopes, App.PCA.Users.FirstOrDefault());
+            RefreshUserData(ar.AccessToken);
+            btnSignInSignOut.Text = "Sign out";
+        }
+        catch
+        {
+            // doesn't matter, we go in interactive more
+            btnSignInSignOut.Text = "Sign in";
+        }
     }
-    catch
-    {
-        // doesn't matter, we go in interactive more
-        btnSignInSignOut.Text = "Sign in";
-    }
-}
-
+    
 ```
+- If the attempt to obtain a token silently fails, we do nothing and display the screen with the sign in button (at the bottom of the application).
+- When the sign in button is pressed, we execute the same logic - but using a method that shows interactive UX:
 
-If the attempt to obtain a token silently fails, we do nothing and display the screen with the sign in button.
-When the sign in button is pressed, we execute the same logic - but using a method that shows interactive UX:
-
-```
+```C#
 AuthenticationResult ar = await App.PCA.AcquireTokenAsync(App.Scopes, App.UiParent);
 ```
-The `Scopes` parameter indicates the permissions the application needs to gain access to the data requested throuhg subsequent web API call (in this sample, encapsulated in `RefreshUserData`). 
-The UiParent is used in Android to tie the authentication flow to the current activity, and is ignored on all other platforms. For more platform specific considerations, please see below.
 
-The sign out logic is very simple. In this sample we have just one user, however we are demonstrating a more generic sign out logic that you can apply if you have multiple concurrent users and you want to clear up the entire cache.               
-```
-foreach (var user in App.PCA.Users)
-{
-    App.PCA.Remove(user);
-}
-```
+- The `Scopes` parameter indicates the permissions the application needs to gain access to the data requested through subsequent web API call (in this sample, encapsulated in `RefreshUserData`). 
+The `UiParent` is used in Android to tie the authentication flow to the current activity, and is ignored on all other platforms. For more platform specific considerations, please see below.
+
+- The sign out logic is very simple. In this sample we have just one user, however we are demonstrating a more generic sign out logic that you can apply if you have multiple concurrent users and you want to clear up the entire cache.               
+    ```C#
+    foreach (var user in App.PCA.Users.ToArray())
+    {
+        App.PCA.Remove(user);
+    }
+    ```
 
 ### Android specific considerations
 The platform specific projects require only a couple of extra lines to accommodate for individual platform differences.
 
-UserDetailsClient.Droid requires one two extra lines in the `MainActivity.cs` file.
+The `UserDetailsClient.Droid` project requires two extra lines in the `MainActivity.cs` file.
 In `OnActivityResult`, we need to add
 
-```
+```C#
 AuthenticationContinuationHelper.SetAuthenticationContinuationEventArgs(requestCode, resultCode, data);
 
 ```
 That line ensures that the control goes back to MSAL once the interactive portion of the authentication flow ended.
 
 In `OnCreate`, we need to add the following assignment:
-```
+```C#
 App.UiParent = new UIParent(Xamarin.Forms.Forms.Context as Activity); 
 ```
 That code ensures that the authentication flows occur in the context of the current activity.  
 
-
 ### iOS specific considerations
 
-UserDetailsClient.iOS only requires one extra line, in AppDelegate.cs.
-You need to ensure that the OpenUrl handler looks as ine snippet below:
-```
+The `UserDetailsClient.iOS` project only requires one extra line, in `AppDelegate.cs`.
+You need to ensure that the OpenUrl handler looks as the snippet below:
+```C#
 public override bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
 {
     AuthenticationContinuationHelper.SetAuthenticationContinuationEventArgs(url, "");
@@ -171,6 +174,40 @@ public override bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
 ```
 Once again, this logic is meant to ensure that once the interactive portion of the authentication flow is concluded, the flow goes back to MSAL.
 
+### UWP specific considerations
+You can set the `UseCorporateNework` boolean to `true` to benefit from windows integrated authentication (and therefore SSO with the user signed-in with the operating system) if this user is signed-in with an account in a federated Azure AD tenant. This leverages WAB (Web Authentication Broker). Setting this property to true assumes that the application developer has enabled Windows Integrated Authentication (WIA) in the application. For this, in the `Package.appxmanifest` for your UWP application, in the Capabilities tab, enable the following capabilities: 
+- Enterprise Authentication
+- Private Networks (Client & Server)
+- Shared User Certificate
+ 
+WIA is not enabled by default because applications requesting the Enterprise Authentication or Shared User Certificates capabilities require a higher level of verification to be accepted into the Windows Store, and not all developers may wish to perform the higher level of verification.
+
+## Troubleshooting
+###  Some projects don't load in Visual Studio
+This might be because you have not installed all the required components from Visual Studio. you need'll need to add the **Mobile development with .NET** [workload](https://www.visualstudio.com/vs/visual-studio-workloads/), in the Visual Studio Installer.
+
+### The project you want is not built
+you need to right click on the visual studio solution, choose **Configuration Properties** > **Configuration** and make sure that you check the projects and configuration you want to build (and deploy)
+
+### Testing UWP applications on Windows 10
+- you might want to right click on the `UserDetailsClient.UWP (Universal Windows)` project and, in the **Application** tab, change the Universal Windows **Target** and **Min Version** depending on the SDK you have installed on your machine. 
+- To install more Windows 10 SDKs, run **Visual Studio Installer**, choose your Visual Studio installation, click on **Modify**, and in the **Individual components** tab, in the **SDKs, Libraries, and frameworks** section, make sure you check all the Windows 10 SDK versions that you need.
+
+### On Windows 10 store apps, you cannot sign-in with your windows hello PIN
+If sign-in with your work or school account and your organization requires conditional access, you are asked to provide a certificate. 
+- If you did not enabled UWP specific considerations above, you will get this error:
+    ```
+    No valid client certificate found in the request. No valid certificates found in the user's certificate store. Please try again choosing a different authentication method. 
+    ```
+- On Windows 10 desktop UWP application, if you enabled the settings described in [UWP specific considerations](#UWP-specific-considerations), the list of certificates is presented, however if you choose to use your PIN, the PIN window is never presented. This is a known limitation with Web authentication broker in UWP applications running on Windows 10 (this works fine on Windows Phone 10). As a work around, you will need to click on the **sign in with other options** link and then choose **Sign-in with a username and password instead**, provide your password and go through the phone authentication.
+
 
 ## More information
-For more information, please visit the [new documentation homepage for Microsoft identity](http://aka.ms/aaddevv2). 
+For more information, please visit:
+- For more information on acquiring tokens with MSAL.NET, please visit [MSAL.NET's conceptual documentation](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki), in particular:
+    - [PublicClientApplication](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Client-Applications#publicclientapplication)
+    - [Recommended call pattern in public client applications](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/AcquireTokenSilentAsync-using-a-cached-token#recommended-call-pattern-in-public-client-applications)
+    - [Acquiring tokens interactively in public client application flows](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Acquiring-tokens-interactively)
+- To undestand more about the AAD V2 endpoint see http://aka.ms/aaddevv2 
+- For more information about how the protocols work in this scenario and other scenarios, see [Authentication Scenarios for Azure AD](http://go.microsoft.com/fwlink/?LinkId=394414).
+- For more information about Microsoft Graph, please visit [the Microsoft Graph homepage](https://graph.microsoft.io/en-us/)

--- a/UserDetailsClient/UserDetailsClient.iOS/Info.plist
+++ b/UserDetailsClient/UserDetailsClient.iOS/Info.plist
@@ -36,7 +36,7 @@
    </array>
 	
     <key>MinimumOSVersion</key>
-    <string>6.0</string>
+    <string>7.0</string>
     <key>CFBundleDisplayName</key>
     <string>UserDetailsClient</string>
     <key>CFBundleIdentifier</key>

--- a/active-directory-Xamarin-native-v2.sln
+++ b/active-directory-Xamarin-native-v2.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UserDetailsClient.Droid", "UserDetailsClient\UserDetailsClient.Droid\UserDetailsClient.Droid.csproj", "{DD942D28-518D-4C06-A0D9-A7D8AB3F54E7}"
 EndProject
@@ -10,6 +10,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UserDetailsClient.UWP", "UserDetailsClient\UserDetailsClient.UWP\UserDetailsClient.UWP.csproj", "{CB126428-9739-4C4E-9CBB-F09C03080415}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UserDetailsClient", "UserDetailsClient\UserDetailsClient\UserDetailsClient.csproj", "{CF72088B-E0A5-401C-A795-531A81E05248}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{36FE7FD1-5D6E-4733-8B43-D3A14A3D5539}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -257,5 +262,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DE374F73-BB5C-4BF7-9009-79A424F43173}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Improving the `README.md`
  - adding metadata
  - Adding details for UWP (including a UWP specific considerations section)
  - Improving the code highlighting for code snippets
  - Adding a **Troubleshooting** section (when projects don't load, project don't build, testing UWP apps on Windows 10, and Windows hello PIN issue on Windows 10 store apps.
  - Adding a **More information** section with links to documentation
- Setting the `MinimumOSVersion` for iOS in `info.plist` to 7.0 to avoid the error on Xamarin.iOS.Common.Targets that compiling IB doucments for ealier than iOS7 is no longer supported.