### PR TITLE
[WIP] Enabled keychain on Entitlements.plist file and added the iOS bundle …

### DIFF
--- a/UserDetailsClient/UserDetailsClient.iOS/Entitlements.plist
+++ b/UserDetailsClient/UserDetailsClient.iOS/Entitlements.plist
@@ -1,7 +1,10 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>com.yourcompany.UserDetailsClient</string>
+	</array>
 </dict>
 </plist>
-


### PR DESCRIPTION
Enable keychain on Entitlements.plist file and add the iOS bundle identifier in order to make token persistence work on the iOS sample.

In order to make the sample fully work, as I mentioned in the doc you have to use this entitlement file as a Custom Entitlements. However, if I declare it, the app won't compile as there is no provisioning profile configured by default with the sample.
Do you prefer having the Entitlement configured in Bundle Signing Options but the app doesn't compile, or no Entitlement configured, the app compile but doesn't work ?

I can make another commit if you pick the first option, otherwise you can merge.