### PR TITLE
Jennyf/fixes

### DIFF
--- a/UserDetailsClient/UserDetailsClient.iOS/UserDetailsClient.iOS.csproj
+++ b/UserDetailsClient/UserDetailsClient.iOS/UserDetailsClient.iOS.csproj
@@ -27,6 +27,7 @@
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>


### PR DESCRIPTION
Fix iOS simulator issue w/TeamID() returning null and sending out a null ref when creating a public client app.
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/617