### PR TITLE
Added WithIosKeychainSecurityGroup for ios

### DIFF
--- a/1-Basic/UserDetailsClient/UserDetailsClient/App.cs
+++ b/1-Basic/UserDetailsClient/UserDetailsClient/App.cs
@@ -22,7 +22,7 @@ namespace UserDetailsClient
         {
             PCA = PublicClientApplicationBuilder.Create(ClientID)
                 .WithRedirectUri($"msal{ClientID}://auth")
-				.WithIosKeychainSecurityGroup("com.microsoft.adalcache")
+                .WithIosKeychainSecurityGroup("com.microsoft.adalcache")
 				.Build();
 
             MainPage = new NavigationPage(new UserDetailsClient.MainPage());

--- a/1-Basic/UserDetailsClient/UserDetailsClient/App.cs
+++ b/1-Basic/UserDetailsClient/UserDetailsClient/App.cs
@@ -23,7 +23,7 @@ namespace UserDetailsClient
             PCA = PublicClientApplicationBuilder.Create(ClientID)
                 .WithRedirectUri($"msal{ClientID}://auth")
                 .WithIosKeychainSecurityGroup("com.microsoft.adalcache")
-				.Build();
+                .Build();
 
             MainPage = new NavigationPage(new UserDetailsClient.MainPage());
         }

--- a/1-Basic/UserDetailsClient/UserDetailsClient/App.cs
+++ b/1-Basic/UserDetailsClient/UserDetailsClient/App.cs
@@ -22,7 +22,8 @@ namespace UserDetailsClient
         {
             PCA = PublicClientApplicationBuilder.Create(ClientID)
                 .WithRedirectUri($"msal{ClientID}://auth")
-                .Build();
+				.WithIosKeychainSecurityGroup("com.microsoft.adalcache")
+				.Build();
 
             MainPage = new NavigationPage(new UserDetailsClient.MainPage());
         }


### PR DESCRIPTION
The reason why is adding WithIosKeychainSecurityGroup for ios because the keychain is not cached and you can not get an access token if you use different keychain groups with the same Client ID.