### PR TITLE
Update to fix the app crash on Exception

### DIFF
--- a/1-Basic/UserDetailsClient/UserDetailsClient/MainPage.xaml.cs
+++ b/1-Basic/UserDetailsClient/UserDetailsClient/MainPage.xaml.cs
@@ -55,7 +55,10 @@ namespace UserDetailsClient
                         }
                         catch (Exception ex2)
                         {
-                            await DisplayAlert("Acquire token interactive failed. See exception message for details: ", ex2.Message, "Dismiss");
+                            Device.BeginInvokeOnMainThread(async () =>
+                            {
+                                await DisplayAlert("Acquire token interactive failed. See exception message for details: ", ex2.Message, "Dismiss");
+                            });
                         }
                     }
 
@@ -83,7 +86,10 @@ namespace UserDetailsClient
             }
             catch (Exception ex)
             {
-                await DisplayAlert("Authentication failed. See exception message for details: ", ex.Message, "Dismiss");
+                Device.BeginInvokeOnMainThread(async () =>
+                {
+                    await DisplayAlert("Authentication failed. See exception message for details: ", ex.Message, "Dismiss");
+                });
             }
         }
 
@@ -122,7 +128,10 @@ namespace UserDetailsClient
             }
             catch(Exception ex)
             {
-                await DisplayAlert("API call to graph failed: ", ex.Message, "Dismiss").ConfigureAwait(false);
+                Device.BeginInvokeOnMainThread(async () =>
+                {
+                    await DisplayAlert("API call to graph failed: ", ex.Message, "Dismiss").ConfigureAwait(false);
+                });
                 return ex.ToString();
             }
         }


### PR DESCRIPTION
If the authentication pop up window is closed (in UWP) application crashes dues to DisplayAlert method being invoked on non UI thread.